### PR TITLE
s3 api V2を使用しているgemをv4を使用するものに変更。

### DIFF
--- a/lib/mamiya/storages/s3.rb
+++ b/lib/mamiya/storages/s3.rb
@@ -1,6 +1,6 @@
 require 'mamiya/package'
 require 'mamiya/storages/abstract'
-require 'aws-sdk-core'
+require 'aws-sdk-s3'
 require 'json'
 
 PART_SIZE=1024*1024*100

--- a/mamiya.gemspec
+++ b/mamiya.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "thor", ">= 0.18.1"
-  spec.add_runtime_dependency "aws-sdk-core", ">= 2.0.0"
+  spec.add_runtime_dependency "aws-sdk-s3", ">= 1"
   spec.add_runtime_dependency "term-ansicolor", ">= 1.3.0"
   unless ENV["MAMIYA_VILLEIN_PATH"]
     spec.add_runtime_dependency "villein", ">= 0.5.0"


### PR DESCRIPTION
Amazon S3のAWS署名バーション4対応。